### PR TITLE
allow simplecache

### DIFF
--- a/ci/environment-upstream-dev.yml
+++ b/ci/environment-upstream-dev.yml
@@ -5,18 +5,18 @@ dependencies:
   - python=*=*cp*
   - aiohttp
   - codecov
-  - intake-xarray
+  - fsspec>=0.8.5
+  - h5netcdf>=0.8.1
+  - intake-xarray>=0.3
   - netcdf4
   - pip
+  - pydap
   - pytest
   - pytest-cov
   - pytest-icdiff
   - pytest-xdist
   - tqdm
   - xarray
-  - pydap
-  - aiohttp
-  - h5netcdf
   - pip:
       - git+https://github.com/intake/intake.git
       - git+https://github.com/Unidata/siphon.git

--- a/ci/environment-upstream-dev.yml
+++ b/ci/environment-upstream-dev.yml
@@ -15,6 +15,7 @@ dependencies:
   - xarray
   - pydap
   - aiohttp
+  - h5netcdf
   - pip:
       - git+https://github.com/intake/intake.git
       - git+https://github.com/Unidata/siphon.git

--- a/ci/environment-upstream-dev.yml
+++ b/ci/environment-upstream-dev.yml
@@ -2,6 +2,7 @@ name: intake-thredds-dev
 channels:
   - conda-forge
 dependencies:
+  - python=*=*cp*
   - aiohttp
   - codecov
   - intake-xarray

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -17,3 +17,4 @@ dependencies:
   - xarray
   - pydap
   - aiohttp
+  - h5netcdf

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -3,12 +3,15 @@ channels:
   - conda-forge
 dependencies:
   - python=*=*cp*
-  - aiohttp
+  - aiohttp>=3.7
   - codecov
-  - intake
-  - intake-xarray
+  - fsspec>=0.8.5
+  - h5netcdf>=0.8.1
+  - intake>=0.6.0
+  - intake-xarray>=0.3
   - netcdf4
   - pip
+  - pydap
   - pytest
   - pytest-cov
   - pytest-icdiff
@@ -16,6 +19,3 @@ dependencies:
   - siphon
   - tqdm
   - xarray
-  - pydap
-  - aiohttp
-  - h5netcdf

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -2,6 +2,7 @@ name: intake-thredds-dev
 channels:
   - conda-forge
 dependencies:
+  - python=*=*cp*
   - aiohttp
   - codecov
   - intake

--- a/intake_thredds/cat.py
+++ b/intake_thredds/cat.py
@@ -5,8 +5,9 @@ from intake.catalog.local import LocalCatalogEntry
 class ThreddsCatalog(Catalog):
     name = 'thredds_cat'
 
-    def __init__(self, url, **kwargs):
+    def __init__(self, url, driver='opendap', **kwargs):
         self.url = url
+        self.driver = driver
         super().__init__(**kwargs)
 
     def _load(self):
@@ -34,16 +35,18 @@ class ThreddsCatalog(Catalog):
         }
 
         # data entries (only those with opendap links)
+        if self.driver == 'opendap':
+            driver_for_access_urls = 'OPENDAP'
+        elif self.driver == 'netcdf':
+            driver_for_access_urls = 'HTTPServer'
         self._entries.update(
             {
                 ds.name: LocalCatalogEntry(
                     ds.name,
                     'THREDDS data',
-                    # 'netcdf',
-                    'opendap',
+                    self.driver,
                     True,
-                    # {'urlpath': ds.access_urls['HTTPServer'], 'chunks': None},
-                    {'urlpath': ds.access_urls['OPENDAP'], 'chunks': None},
+                    {'urlpath': ds.access_urls[driver_for_access_urls], 'chunks': None},
                     [],
                     [],
                     {},

--- a/intake_thredds/cat.py
+++ b/intake_thredds/cat.py
@@ -17,7 +17,7 @@ class ThreddsCatalog(Catalog):
             if self.driver == 'netcdf':
                 self.cache = True
                 self.url_no_simplecache = self.url.replace('simplecache::', '')
-                self.metadata.update({'cache': 'simplecache::'})
+                self.metadata.update({'fsspec_pre_url': 'simplecache::'})
             else:
                 raise ValueError(
                     f'simplecache requires driver="netcdf", found driver="{self.driver}".'
@@ -53,8 +53,8 @@ class ThreddsCatalog(Catalog):
             elif self.driver == 'netcdf':
                 driver_for_access_urls = 'HTTPServer'
             url = ds.access_urls[driver_for_access_urls]
-            if 'cache' in self.metadata.keys():
-                url = f'{self.metadata["cache"]}{url}'
+            if 'fsspec_pre_url' in self.metadata.keys():
+                url = f'{self.metadata["fsspec_pre_url"]}{url}'
             return url
 
         self._entries.update(

--- a/intake_thredds/cat.py
+++ b/intake_thredds/cat.py
@@ -12,19 +12,22 @@ class ThreddsCatalog(Catalog):
 
     def _load(self):
         from siphon.catalog import TDSCatalog
+        #print(self.cache, self.url)
 
         if 'simplecache::' in self.url:
             if self.driver == 'netcdf':
-                use_simplecache = True
-                self.url = self.url.replace('simplecache::', '')
+                self.cache = True
+                self.url_no_simplecache = self.url.replace('simplecache::', '')
+                self.metadata.update({'cache':'simplecache::'})
             else:
                 raise ValueError(
-                    'simplecache requires driver="netcdf", found driver="{self.driver}".'
+                    f'simplecache requires driver="netcdf", found driver="{self.driver}".'
                 )
         else:
-            use_simplecache = False
+            self.cache = False
+            self.url_no_simplecache = self.url
 
-        self.cat = TDSCatalog(self.url)
+        self.cat = TDSCatalog(self.url_no_simplecache)
         self.name = self.cat.catalog_name
         self.metadata.update(self.cat.metadata)
 
@@ -38,24 +41,28 @@ class ThreddsCatalog(Catalog):
                 {'url': r.href},
                 [],
                 [],
-                {},
+                self.metadata,
                 None,
                 catalog=self,
             )
             for r in self.cat.catalog_refs.values()
         }
 
-        def access_urls(ds, use_simplecache, self):
+        def access_urls(ds, self):
             # data entries (only those with opendap links)
             if self.driver == 'opendap':
                 driver_for_access_urls = 'OPENDAP'
             elif self.driver == 'netcdf':
                 driver_for_access_urls = 'HTTPServer'
             url = ds.access_urls[driver_for_access_urls]
-            if use_simplecache:
-                url = f'simplecache::{url}'
+            if 'cache' in self.metadata.keys():
+                #print('access_urls add simplecache')
+                url = f'{self.metadata["cache"]}{url}'
+            #else:
+                #print('access_urls dont add simplecache')
             return url
 
+        #print('self.driver',self.driver, 'self.cache', self.cache)
         self._entries.update(
             {
                 ds.name: LocalCatalogEntry(
@@ -63,7 +70,7 @@ class ThreddsCatalog(Catalog):
                     'THREDDS data',
                     self.driver,
                     True,
-                    {'urlpath': access_urls(ds, use_simplecache, self), 'chunks': None},
+                    {'urlpath': access_urls(ds, self), 'chunks': None},
                     [],
                     [],
                     {},

--- a/intake_thredds/cat.py
+++ b/intake_thredds/cat.py
@@ -19,7 +19,8 @@ class ThreddsCatalog(Catalog):
                 self.url = self.url.replace('simplecache::', '')
             else:
                 raise ValueError(
-                    'simplecache requires driver="netcdf", found driver="{self.driver}".')
+                    'simplecache requires driver="netcdf", found driver="{self.driver}".'
+                )
         else:
             use_simplecache = False
 

--- a/intake_thredds/cat.py
+++ b/intake_thredds/cat.py
@@ -12,13 +12,12 @@ class ThreddsCatalog(Catalog):
 
     def _load(self):
         from siphon.catalog import TDSCatalog
-        #print(self.cache, self.url)
 
         if 'simplecache::' in self.url:
             if self.driver == 'netcdf':
                 self.cache = True
                 self.url_no_simplecache = self.url.replace('simplecache::', '')
-                self.metadata.update({'cache':'simplecache::'})
+                self.metadata.update({'cache': 'simplecache::'})
             else:
                 raise ValueError(
                     f'simplecache requires driver="netcdf", found driver="{self.driver}".'
@@ -49,20 +48,15 @@ class ThreddsCatalog(Catalog):
         }
 
         def access_urls(ds, self):
-            # data entries (only those with opendap links)
             if self.driver == 'opendap':
                 driver_for_access_urls = 'OPENDAP'
             elif self.driver == 'netcdf':
                 driver_for_access_urls = 'HTTPServer'
             url = ds.access_urls[driver_for_access_urls]
             if 'cache' in self.metadata.keys():
-                #print('access_urls add simplecache')
                 url = f'{self.metadata["cache"]}{url}'
-            #else:
-                #print('access_urls dont add simplecache')
             return url
 
-        #print('self.driver',self.driver, 'self.cache', self.cache)
         self._entries.update(
             {
                 ds.name: LocalCatalogEntry(

--- a/intake_thredds/cat.py
+++ b/intake_thredds/cat.py
@@ -18,8 +18,8 @@ class ThreddsCatalog(Catalog):
                 use_simplecache = True
                 self.url = self.url.replace('simplecache::', '')
             else:
-                raise ValueError('simplecache requires driver="netcdf", '
-                                f'found driver="{self.driver}".')
+                raise ValueError(
+                    'simplecache requires driver="netcdf", found driver="{self.driver}".')
         else:
             use_simplecache = False
 

--- a/intake_thredds/source.py
+++ b/intake_thredds/source.py
@@ -16,7 +16,7 @@ class THREDDSMergedSource(DataSourceMixin):
     name = 'thredds_merged'
     partition_access = True
 
-    def __init__(self, url, path, progressbar=True, metadata=None):
+    def __init__(self, url, path, driver='opendap', progressbar=True, metadata=None):
         """
 
         Parameters
@@ -26,6 +26,8 @@ class THREDDSMergedSource(DataSourceMixin):
         path : list of str
             Subcats to follow; include glob characters (*, ?) in here for
             matching
+        driver : str
+            Select driver to access data. Choose from 'netcdf' and 'opendap'.
         progressbar : bool
             If True, will print a progress bar. Requires `tqdm <https://github.com/tqdm/tqdm>`__
             to be installed.
@@ -34,7 +36,10 @@ class THREDDSMergedSource(DataSourceMixin):
         """
         super(THREDDSMergedSource, self).__init__(metadata=metadata)
         self.urlpath = url
+        if 'simplecache' in url:
+            self.metadata.update({'cache':'simplecache::'})
         self.path = path
+        self.driver = driver
         self._ds = None
         self.progressbar = progressbar
         if self.progressbar and tqdm is None:
@@ -44,14 +49,17 @@ class THREDDSMergedSource(DataSourceMixin):
         import xarray as xr
 
         if self._ds is None:
-            cat = ThreddsCatalog(self.urlpath)
+            cat = ThreddsCatalog(self.urlpath, driver=self.driver)
             for i in range(len(self.path)):
                 part = self.path[i]
                 if '*' not in part and '?' not in part:
-                    cat = cat[part]()
+                    #print(i,'before',part,self.driver)
+                    cat = cat[part](driver=self.driver)
+                    #print(i,'after',self.driver,'\n')
                 else:
                     break
             path = self.path[i:]
+            #print(path, _match(cat, path)[0], _match(cat, path)[-1])
             if self.progressbar:
                 data = [ds.to_dask() for ds in tqdm(_match(cat, path), desc='Dataset(s)', ncols=79)]
             else:

--- a/intake_thredds/source.py
+++ b/intake_thredds/source.py
@@ -36,8 +36,8 @@ class THREDDSMergedSource(DataSourceMixin):
         """
         super(THREDDSMergedSource, self).__init__(metadata=metadata)
         self.urlpath = url
-        if 'simplecache' in url:
-            self.metadata.update({'cache': 'simplecache::'})
+        if 'simplecache::' in url:
+            self.metadata.update({'fsspec_pre_url': 'simplecache::'})
         self.path = path
         self.driver = driver
         self._ds = None

--- a/intake_thredds/source.py
+++ b/intake_thredds/source.py
@@ -37,7 +37,7 @@ class THREDDSMergedSource(DataSourceMixin):
         super(THREDDSMergedSource, self).__init__(metadata=metadata)
         self.urlpath = url
         if 'simplecache' in url:
-            self.metadata.update({'cache':'simplecache::'})
+            self.metadata.update({'cache': 'simplecache::'})
         self.path = path
         self.driver = driver
         self._ds = None
@@ -53,13 +53,10 @@ class THREDDSMergedSource(DataSourceMixin):
             for i in range(len(self.path)):
                 part = self.path[i]
                 if '*' not in part and '?' not in part:
-                    #print(i,'before',part,self.driver)
                     cat = cat[part](driver=self.driver)
-                    #print(i,'after',self.driver,'\n')
                 else:
                     break
             path = self.path[i:]
-            #print(path, _match(cat, path)[0], _match(cat, path)[-1])
             if self.progressbar:
                 data = [ds.to_dask() for ds in tqdm(_match(cat, path), desc='Dataset(s)', ncols=79)]
             else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ intake-xarray>=0.3
 intake>=0.6.0
 pydap
 siphon
+h5netcdf

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 aiohttp>=3.7
 intake-xarray>=0.3
 intake>=0.6.0
+fsspec >=0.8.5
 pydap
 siphon
-h5netcdf
+h5netcdf>=0.8.1

--- a/tests/test_cat.py
+++ b/tests/test_cat.py
@@ -6,10 +6,12 @@ import xarray as xr
 
 @pytest.fixture(scope='module')
 def thredds_cat_url():
+    """Single file thredds catalog."""
     return 'https://psl.noaa.gov/thredds/catalog/Datasets/noaa.ersst/catalog.xml'
 
 
-def test_init_catalog(thredds_cat_url):
+def test_ThreddsCatalog_init_catalog(thredds_cat_url):
+    """Test initialization of ThreddsCatalog."""
     cat = intake.open_thredds_cat(thredds_cat_url)
     assert isinstance(cat, intake.catalog.Catalog)
     assert cat.metadata == cat.cat.metadata
@@ -22,16 +24,16 @@ def test_init_catalog(thredds_cat_url):
 
 
 @pytest.mark.parametrize('driver', ['netcdf', 'opendap'])
-def test_entry(thredds_cat_url, driver):
+def test_ThreddsCatalog(thredds_cat_url, driver):
     """Test entry.to_dask() is xr.Dataset and allows opendap and netcdf as source."""
     cat = intake.open_thredds_cat(thredds_cat_url, driver=driver)
-    entry = cat['err.mnmean.v3.nc']
+    entry = cat['sst.mon.19712000.ltm.v3.nc']
     if driver == 'opendap':
         assert isinstance(entry, intake_xarray.opendap.OpenDapSource)
     elif driver == 'netcdf':
         assert isinstance(entry, intake_xarray.netcdf.NetCDFSource)
     d = entry.describe()
-    assert d['name'] == 'err.mnmean.v3.nc'
+    assert d['name'] == 'sst.mon.19712000.ltm.v3.nc'
     assert d['container'] == 'xarray'
     assert d['plugin'] == [driver]
     if driver == 'opendap':
@@ -40,29 +42,32 @@ def test_entry(thredds_cat_url, driver):
         loc = 'fileServer'
     assert (
         d['args']['urlpath']
-        == f'https://psl.noaa.gov/thredds/{loc}/Datasets/noaa.ersst/err.mnmean.v3.nc'
+        == f'https://psl.noaa.gov/thredds/{loc}/Datasets/noaa.ersst/sst.mon.19712000.ltm.v3.nc'
     )
     ds = entry(chunks={}).to_dask()
     assert isinstance(ds, xr.Dataset)
 
 
-def test_entry_simplecache_netcdf(thredds_cat_url):
-    """Test allow simplecache:: in url if netcdf as source."""
+def test_ThreddsCatalog_simplecache_netcdf(thredds_cat_url):
+    """Test that ThreddsCatalog allows simplecache:: in url if netcdf as source."""
     import os
 
     import fsspec
 
     fsspec.config.conf['simplecache'] = {'cache_storage': 'my_caching_folder', 'same_names': True}
     cat = intake.open_thredds_cat(f'simplecache::{thredds_cat_url}', driver='netcdf')
-    entry = cat['err.mnmean.v3.nc']
+    entry = cat['sst.mon.19712000.ltm.v3.nc']
     ds = entry(chunks={}).to_dask()
     assert isinstance(ds, xr.Dataset)
     # test files present
-    os.path.exists('my_caching_folder/err.mnmean.v3.nc')
+    cached_file = 'my_caching_folder/sst.mon.19712000.ltm.v3.nc'
+    assert os.path.exists(cached_file)
+    os.remove(cached_file)
+    assert not os.path.exists(cached_file)
 
 
-def test_entry_simplecache_fails_opendap(thredds_cat_url):
-    """Test no simplecache:: in url with opendap."""
+def test_ThreddsCatalog_simplecache_fails_opendap(thredds_cat_url):
+    """Test that ThreddsCatalog simplecache:: in url with opendap."""
     with pytest.raises(ValueError) as e:
         intake.open_thredds_cat(f'simplecache::{thredds_cat_url}', driver='opendap')
     assert 'simplecache requires driver="netcdf"' in str(e.value)

--- a/tests/test_cat.py
+++ b/tests/test_cat.py
@@ -17,10 +17,7 @@ def test_init_catalog(thredds_cat_url):
 
     assert 'err.mnmean.v3.nc' in cat
 
-    cat = intake.open_thredds_cat(
-        thredds_cat_url,
-        metadata={'random_attribute': 'thredds'}
-    )
+    cat = intake.open_thredds_cat(thredds_cat_url, metadata={'random_attribute': 'thredds'})
     assert 'random_attribute' in cat.metadata
 
 
@@ -51,12 +48,10 @@ def test_entry(thredds_cat_url, driver):
 
 def test_entry_simplecache(thredds_cat_url):
     """Test allow simplecache:: in url if netcdf as source."""
-    import fsspec
     import os
-    fsspec.config.conf['simplecache'] = {
-        'cache_storage': 'my_caching_folder',
-        'same_names': True
-    }
+
+    import fsspec
+    fsspec.config.conf['simplecache'] = {'cache_storage': 'my_caching_folder', 'same_names': True}
     cat = intake.open_thredds_cat(f'simplecache::{thredds_cat_url}', driver='netcdf')
     entry = cat['err.mnmean.v3.nc']
     ds = entry(chunks={}).to_dask()
@@ -68,8 +63,5 @@ def test_entry_simplecache(thredds_cat_url):
 def test_entry_simplecache(thredds_cat_url):
     """Test no simplecache:: in url with opendap."""
     with pytest.raises(ValueError) as e:
-        cat = intake.open_thredds_cat(
-            f'simplecache::{thredds_cat_url}',
-            driver='opendap'
-        )
+        cat = intake.open_thredds_cat(f'simplecache::{thredds_cat_url}',driver='opendap')
     assert 'simplecache requires driver="netcdf"' in str(e.value)

--- a/tests/test_cat.py
+++ b/tests/test_cat.py
@@ -68,6 +68,5 @@ def test_ThreddsCatalog_simplecache_netcdf(thredds_cat_url):
 
 def test_ThreddsCatalog_simplecache_fails_opendap(thredds_cat_url):
     """Test that ThreddsCatalog simplecache:: in url with opendap."""
-    with pytest.raises(ValueError) as e:
+    with pytest.raises(ValueError, match=r'simplecache requires driver="netcdf"'):
         intake.open_thredds_cat(f'simplecache::{thredds_cat_url}', driver='opendap')
-    assert 'simplecache requires driver="netcdf"' in str(e.value)

--- a/tests/test_cat.py
+++ b/tests/test_cat.py
@@ -46,7 +46,7 @@ def test_entry(thredds_cat_url, driver):
     assert isinstance(ds, xr.Dataset)
 
 
-def test_entry_simplecache(thredds_cat_url):
+def test_entry_simplecache_netcdf(thredds_cat_url):
     """Test allow simplecache:: in url if netcdf as source."""
     import os
 
@@ -61,8 +61,8 @@ def test_entry_simplecache(thredds_cat_url):
     os.path.exists('my_caching_folder/err.mnmean.v3.nc')
 
 
-def test_entry_simplecache(thredds_cat_url):
+def test_entry_simplecache_fails_opendap(thredds_cat_url):
     """Test no simplecache:: in url with opendap."""
     with pytest.raises(ValueError) as e:
-        cat = intake.open_thredds_cat(f'simplecache::{thredds_cat_url}', driver='opendap')
+        intake.open_thredds_cat(f'simplecache::{thredds_cat_url}', driver='opendap')
     assert 'simplecache requires driver="netcdf"' in str(e.value)

--- a/tests/test_cat.py
+++ b/tests/test_cat.py
@@ -51,6 +51,7 @@ def test_entry_simplecache(thredds_cat_url):
     import os
 
     import fsspec
+
     fsspec.config.conf['simplecache'] = {'cache_storage': 'my_caching_folder', 'same_names': True}
     cat = intake.open_thredds_cat(f'simplecache::{thredds_cat_url}', driver='netcdf')
     entry = cat['err.mnmean.v3.nc']
@@ -63,5 +64,5 @@ def test_entry_simplecache(thredds_cat_url):
 def test_entry_simplecache(thredds_cat_url):
     """Test no simplecache:: in url with opendap."""
     with pytest.raises(ValueError) as e:
-        cat = intake.open_thredds_cat(f'simplecache::{thredds_cat_url}',driver='opendap')
+        cat = intake.open_thredds_cat(f'simplecache::{thredds_cat_url}', driver='opendap')
     assert 'simplecache requires driver="netcdf"' in str(e.value)

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -11,16 +11,18 @@ def THREDDSMergedSource_cat():
         'Datasets',
         'ncep.reanalysis.dailyavgs',
         'surface',
-        'air*sig995*194*.nc',
+        'air*sig995*194*.nc',  # todo: convert . to * ?
     ]
     cat = intake.open_thredds_merged(thredds_cat_url, paths)
     assert cat.urlpath == thredds_cat_url
     assert cat.path == paths
     return cat
 
+
 @pytest.fixture(scope='module')
 def THREDDSMergedSource_cat_short_url():
     return 'https://psl.noaa.gov/thredds/catalog/Datasets/ncep.reanalysis.dailyavgs/surface/catalog.xml'
+
 
 @pytest.fixture(scope='module')
 def THREDDSMergedSource_cat_short_path():
@@ -28,18 +30,28 @@ def THREDDSMergedSource_cat_short_path():
 
 
 @pytest.fixture(scope='module')
-def THREDDSMergedSource_cat_short(THREDDSMergedSource_cat_short_url, THREDDSMergedSource_cat_short_path):
+def THREDDSMergedSource_cat_short(
+    THREDDSMergedSource_cat_short_url, THREDDSMergedSource_cat_short_path
+):
     """THREDDSMergedSource without the looping faster."""
-    cat = intake.open_thredds_merged(THREDDSMergedSource_cat_short_url, THREDDSMergedSource_cat_short_path)
+    cat = intake.open_thredds_merged(
+        THREDDSMergedSource_cat_short_url, THREDDSMergedSource_cat_short_path
+    )
     assert cat.urlpath == THREDDSMergedSource_cat_short_url
     assert cat.path == THREDDSMergedSource_cat_short_path
     return cat
 
 
 @pytest.fixture(scope='module')
-def THREDDSMergedSource_cat_short_simplecache(THREDDSMergedSource_cat_short_url, THREDDSMergedSource_cat_short_path):
+def THREDDSMergedSource_cat_short_simplecache(
+    THREDDSMergedSource_cat_short_url, THREDDSMergedSource_cat_short_path
+):
     """Without the looping faster."""
-    return intake.open_thredds_merged(f'simplecache::{THREDDSMergedSource_cat_short_url}', THREDDSMergedSource_cat_short_path, driver='netcdf')
+    return intake.open_thredds_merged(
+        f'simplecache::{THREDDSMergedSource_cat_short_url}',
+        THREDDSMergedSource_cat_short_path,
+        driver='netcdf',
+    )
 
 
 def test_THREDDSMergedSource(THREDDSMergedSource_cat):
@@ -54,7 +66,7 @@ def test_THREDDSMergedSource(THREDDSMergedSource_cat):
 def test_THREDDSMergedSource_long_short(THREDDSMergedSource_cat, THREDDSMergedSource_cat_short):
     ds = THREDDSMergedSource_cat.to_dask()
     ds_short = THREDDSMergedSource_cat_short.to_dask()
-    xr.testing.assert_equal(ds, ds_short)
+    xr.testing.assert_equal(ds, ds_short)  # TODO: down load data only compare dims, coords, size
 
 
 def test_THREDDSMergedSource_simplecache_netcdf(THREDDSMergedSource_cat_short_simplecache):
@@ -62,6 +74,7 @@ def test_THREDDSMergedSource_simplecache_netcdf(THREDDSMergedSource_cat_short_si
     import os
 
     import fsspec
+
     cache_storage = 'my_caching_folder'
     fsspec.config.conf['simplecache'] = {'cache_storage': cache_storage, 'same_names': True}
     cat = THREDDSMergedSource_cat_short_simplecache
@@ -79,5 +92,7 @@ def test_THREDDSMergedSource_simplecache_netcdf(THREDDSMergedSource_cat_short_si
 def test_THREDDSMergedSource_simplecache_fails_opendap(THREDDSMergedSource_cat_short_url):
     """Test that THREDDSMergedSource simplecache:: in url with opendap."""
     with pytest.raises(ValueError) as e:
-        intake.open_thredds_cat(f'simplecache::{THREDDSMergedSource_cat_short_url}', driver='opendap')
+        intake.open_thredds_cat(
+            f'simplecache::{THREDDSMergedSource_cat_short_url}', driver='opendap'
+        )
     assert 'simplecache requires driver="netcdf"' in str(e.value)

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -1,29 +1,83 @@
 import intake
 import pytest
+import xarray as xr
 
 
 @pytest.fixture(scope='module')
-def thredds_cat_url():
-    return 'http://dap.nci.org.au/thredds/catalog.xml'
-
-
-def test_thredds_merge(thredds_cat_url):
+def THREDDSMergedSource_cat():
+    """THREDDSMergedSource looping through folders."""
+    thredds_cat_url = 'https://psl.noaa.gov/thredds/catalog.xml'
     paths = [
-        'eMAST TERN',
-        'eMAST TERN - files',
-        'ASCAT',
-        'ASCAT_v1-0_soil-moisture_daily_0-05deg_2007-2011',
-        '00000000',
-        '*12.nc',  # to speed up only takes all december files
+        'Datasets',
+        'ncep.reanalysis.dailyavgs',
+        'surface',
+        'air*sig995*194*.nc',
     ]
     cat = intake.open_thredds_merged(thredds_cat_url, paths)
     assert cat.urlpath == thredds_cat_url
     assert cat.path == paths
+    return cat
 
+@pytest.fixture(scope='module')
+def THREDDSMergedSource_cat_short_url():
+    return 'https://psl.noaa.gov/thredds/catalog/Datasets/ncep.reanalysis.dailyavgs/surface/catalog.xml'
+
+@pytest.fixture(scope='module')
+def THREDDSMergedSource_cat_short_path():
+    return ['air.sig995*194*.nc']  # todo: convert . to * ?
+
+
+@pytest.fixture(scope='module')
+def THREDDSMergedSource_cat_short(THREDDSMergedSource_cat_short_url, THREDDSMergedSource_cat_short_path):
+    """THREDDSMergedSource without the looping faster."""
+    cat = intake.open_thredds_merged(THREDDSMergedSource_cat_short_url, THREDDSMergedSource_cat_short_path)
+    assert cat.urlpath == THREDDSMergedSource_cat_short_url
+    assert cat.path == THREDDSMergedSource_cat_short_path
+    return cat
+
+
+@pytest.fixture(scope='module')
+def THREDDSMergedSource_cat_short_simplecache(THREDDSMergedSource_cat_short_url, THREDDSMergedSource_cat_short_path):
+    """Without the looping faster."""
+    return intake.open_thredds_merged(f'simplecache::{THREDDSMergedSource_cat_short_url}', THREDDSMergedSource_cat_short_path, driver='netcdf')
+
+
+def test_THREDDSMergedSource(THREDDSMergedSource_cat):
+    cat = THREDDSMergedSource_cat
     ds = cat.to_dask()
-    assert dict(ds.dims) == {'lat': 681, 'lon': 841, 'time': 155}
+    assert dict(ds.dims) == {'lat': 73, 'lon': 144, 'time': 731}
     d = cat.discover()
     assert set(d['metadata']['coords']) == set(('lat', 'lon', 'time'))
-    assert set(d['metadata']['data_vars'].keys()) == set(
-        ['crs', 'lwe_thickness_of_soil_moisture_content']
-    )
+    assert set(d['metadata']['data_vars'].keys()) == set(['air'])
+
+
+def test_THREDDSMergedSource_long_short(THREDDSMergedSource_cat, THREDDSMergedSource_cat_short):
+    ds = THREDDSMergedSource_cat.to_dask()
+    ds_short = THREDDSMergedSource_cat_short.to_dask()
+    xr.testing.assert_equal(ds, ds_short)
+
+
+def test_THREDDSMergedSource_simplecache_netcdf(THREDDSMergedSource_cat_short_simplecache):
+    """Test that THREDDSMergedSource allows simplecache:: in url if netcdf as source."""
+    import os
+
+    import fsspec
+    cache_storage = 'my_caching_folder'
+    fsspec.config.conf['simplecache'] = {'cache_storage': cache_storage, 'same_names': True}
+    cat = THREDDSMergedSource_cat_short_simplecache
+    ds = cat.to_dask()
+    assert isinstance(ds, xr.Dataset)
+    # test files present
+    cached_files = ['air.sig995.1948.nc', 'air.sig995.1949.nc']
+    for f in cached_files:
+        cached_file = os.path.join(cache_storage, f)
+        assert os.path.exists(cached_file)
+        os.remove(cached_file)
+        assert not os.path.exists(cached_file)
+
+
+def test_THREDDSMergedSource_simplecache_fails_opendap(THREDDSMergedSource_cat_short_url):
+    """Test that THREDDSMergedSource simplecache:: in url with opendap."""
+    with pytest.raises(ValueError) as e:
+        intake.open_thredds_cat(f'simplecache::{THREDDSMergedSource_cat_short_url}', driver='opendap')
+    assert 'simplecache requires driver="netcdf"' in str(e.value)

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -91,8 +91,7 @@ def test_THREDDSMergedSource_simplecache_netcdf(THREDDSMergedSource_cat_short_si
 
 def test_THREDDSMergedSource_simplecache_fails_opendap(THREDDSMergedSource_cat_short_url):
     """Test that THREDDSMergedSource simplecache:: in url with opendap."""
-    with pytest.raises(ValueError) as e:
+    with pytest.raises(ValueError, match=r'simplecache requires driver="netcdf"'):
         intake.open_thredds_cat(
             f'simplecache::{THREDDSMergedSource_cat_short_url}', driver='opendap'
         )
-    assert 'simplecache requires driver="netcdf"' in str(e.value)


### PR DESCRIPTION
1. I allow both netcdf and opendap (default) as drivers.
2. `simplecache::` in filestring allowed

also includes: testing on smaller nc files, but still not self hosted thredds.

Should I generalize for other `actions::` like `zip::/*.nc` or `filecache::`, so far only `simplecache::` but I dont see the need for others in thredds